### PR TITLE
add font styling back to subheading 

### DIFF
--- a/assets/css/screen.css
+++ b/assets/css/screen.css
@@ -3206,7 +3206,12 @@ Usage (In Ghost editor):
     }
 
     .post-full-custom-excerpt {
+        margin: 20px 0 0;
         color: var(--gray);
+        font-family: GraphikRegular, "Helvetica Neue", Helvetica, Arial, sans-serif;
+        font-size: 2.3rem;
+        line-height: 1.4em;
+        font-weight: 400;
     }
 
     .post-full-image {


### PR DESCRIPTION
In[ this PR](https://github.com/daily-co/casper-daily-theme/pull/7/files#diff-9f846c96135156103e1c53da1852572c2d13640f00daa15c273bde29b681d8abL1264) I deleted some code that I shouldn't have 👼 

in this PR, we're adding it back again.

I uploaded this PR to staging and you can see it looks like it should look here: https://blog.staging.daily.co/introducing-the-new-daily-react-hooks-library/