### PR TITLE
Minor design fixes

### DIFF
--- a/assets/css/screen.css
+++ b/assets/css/screen.css
@@ -1525,6 +1525,7 @@ Usage (In Ghost editor):
 
 .post-full-content hr {
     margin: 2em 0;
+    overflow: visible;
 }
 
 .post-full-content hr:after {
@@ -3206,7 +3207,10 @@ Usage (In Ghost editor):
 
     .post-full-content {
         background-color: var(--bluedark);
-
+    }
+  
+    .post-full-content hr:after {
+        box-shadow: var(--bluedark) 0 0 0 5px;
     }
 
     .post-full-custom-excerpt {
@@ -3224,6 +3228,10 @@ Usage (In Ghost editor):
 
     .post-full-byline {
         border-top: 1px solid var(--blue);
+    }
+  
+    .post-full-content blockquote {
+        border-left-color: var(--bluelight);
     }
 
     .post-full-byline-meta h4 a {


### PR DESCRIPTION
This fixes [DEV-1370](https://linear.app/dailyco/issue/DEV-1370/ghost-theme-bug-hr-styling-in-safari-and-firefox), where the diagonal slash in an `hr` was looking off on Firefox.

It also fixes two more issues I found in the meantime:
- The before-mentioned slash did show up at all in Chrome (`overflow:visible` helped this)
- Blockquotes did not have a line on the side in dark mode