### PR TITLE
Remove background-color on .full-post-image

### DIFF
--- a/assets/css/screen.css
+++ b/assets/css/screen.css
@@ -1258,7 +1258,7 @@ make sure this only happens on large viewports / desktop-ish devices.
     overflow: hidden;
     margin: 25px 0 50px;
     width: 100%;
-    background: var(--graylight);
+    background: inherit;
     border-radius: 4px;
 }
 
@@ -3223,7 +3223,7 @@ Usage (In Ghost editor):
     }
 
     .post-full-image {
-        background-color: var(--blue);
+        background-color: inherit;
     }
 
     .post-full-byline {


### PR DESCRIPTION
This fixes [DEV-1530](https://linear.app/dailyco/issue/DEV-1530/blog-platform-transparent-png-images-in-dark-mode), where a different background color on `.post-full-image` (attached to a `<figure>` element in our template).

While Elliott has since replaced the transparent PNG that he used originally with his post, I think it makes sense to correct this issue for the sake of any future transparent PNGs that might appear with a post.

Note that I've set the property to `inherit`, rather than delete it entirely, so that `.post-full-image` should always match with any parent element whose `background-color` is set (the exact behavior you'd want in a transparent-image situation).

Finally, in the name of due diligence, I've checked that the other figure-related class on posts, `.kg-image-card`, does not have a background color set either.