### PR TITLE
Add Hubspot embed to email partial

### DIFF
--- a/partials/subscribe-form.hbs
+++ b/partials/subscribe-form.hbs
@@ -8,57 +8,20 @@
       <div class="sc-bdVaJa iIDDUy">
         <div>
           <div>
-            <p size="16px" color="#434d5d" class="sc-eNQAEJ fBOZaM">Building on
-              video? Subscribe to our newsletter for all the latest product
-              releases, tutorials, and more from Daily.
+            <p size="16px" color="#434d5d" class="sc-eNQAEJ fBOZaM">
+              Don’t miss a thing! Subscribe to our monthly newsletter and we’ll keep you up-to-date
+              with the latest product releases, tutorials, and more from Daily.
             </p>
           </div>
-          <form
-            class="js-cm-form"
-            id="subForm"
-            class="js-cm-form"
-            action="https://www.createsend.com/t/subscribeerror?description="
-            method="post"
-            data-id="2BE4EF332AA2E32596E38B640E905619117D67ADDEE2688559043C25816445C305088B22520F43ECE682232DEF1D117A7A043C5762F1C88B0FD464A6E34F9FE1"
-          >
-            <div size="base" class="sc-jzJRlG bMslyb">
-              <div size="small" class="sc-jzJRlG liOVdz">
-                <div><label
-                    size="14px"
-                    color="#121a24"
-                    class="sc-gzVnrw evxHiW"
-                  >Name </label><input
-                    aria-label="Name"
-                    id="fieldName"
-                    maxLength="200"
-                    name="cm-name"
-                    class="sc-iwsKbI iMsgpL"
-                  /></div>
-              </div>
-              <div size="small" class="sc-jzJRlG liOVdz">
-                <div><label
-                    size="14px"
-                    color="#121a24"
-                    class="sc-gzVnrw evxHiW"
-                  >Email <span class="sc-dnqmqq iFTUZ">*</span></label><input
-                    autoComplete="Email"
-                    aria-label="Email"
-                    id="fieldEmail"
-                    maxLength="200"
-                    name="cm-jrjtlju-jrjtlju"
-                    required
-                    type="email"
-                    class="js-cm-email-input qa-input-email sc-iwsKbI iMsgpL"
-                  /></div>
-              </div>
-              <div size="base" class="sc-jzJRlG bMslyb"></div>
-            </div><button
-              size="16px"
-              color="#121a24"
-              type="submit"
-              class="js-cm-submit-button sc-jKJlTe kvTcQK"
-            >Subscribe</button>
-          </form>
+          <script charset="utf-8" type="text/javascript" src="//js.hsforms.net/forms/v2.js"></script>
+          <script>
+           hbspt.forms.create({
+           region: "na1",
+           portalId: "22536638",
+           formId: "89b9290a-e660-43a2-868f-e03f29eb3610",
+           version: "V2_PRERELEASE"
+           });
+          </script>
         </div>
       </div>
     </div>
@@ -113,7 +76,3 @@
   16px; color: rgb(18, 26, 36); } .fBOZaM { font-size:
   16px; color: rgb(67, 77, 93); }
 </style>
-<script
-  type="text/javascript"
-  src="https://js.createsend1.com/javascript/copypastesubscribeformlogic.js"
-></script>


### PR DESCRIPTION
At Erik's request, this replaces the old email-subscription form with Hubspot.

This is a quick and dirty fix; there is still a bunch of old in-partial CSS from the previous email subscription service that we're relying on to display this box. But Erik just wants this up as quickly as possible. So that's what I've done here.

Note I'm opening this PR against the new staging branch. Fingers crossed the new deploy action works as advertised when we merge this 🤞🏻 

Linear issue: [DEV-1534](https://linear.app/dailyco/issue/DEV-1534/blog-platform-update-newsletter-form-to-point-to-hubspot)