### PR TITLE
Add inline CSS from Hubspot for displaying confirmation in FF

### DIFF
--- a/partials/subscribe-form.hbs
+++ b/partials/subscribe-form.hbs
@@ -13,6 +13,12 @@
               with the latest product releases, tutorials, and more from Daily.
             </p>
           </div>
+          <style>
+          /* Correctly style subscription confirmation in Firefox */
+          @-moz-document url-prefix() {
+            #site-main.site-main .hbspt-form iframe { height: auto; }
+          }
+          </style>
           <script charset="utf-8" type="text/javascript" src="//js.hsforms.net/forms/v2.js"></script>
           <script>
            hbspt.forms.create({


### PR DESCRIPTION
This uses some Firefox-specific hackiness. Hopefully it will be good enough to get the job done for now, but this should be revisited in the near future.