### PR TITLE
Add regrettably necessary !important keyword

### DIFF
--- a/partials/subscribe-form.hbs
+++ b/partials/subscribe-form.hbs
@@ -16,7 +16,7 @@
           <style>
           /* Correctly style subscription confirmation in Firefox */
           @-moz-document url-prefix() {
-            #site-main.site-main .hbspt-form iframe { height: auto; }
+            #site-main.site-main .hbspt-form iframe { height: auto !important; }
           }
           </style>
           <script charset="utf-8" type="text/javascript" src="//js.hsforms.net/forms/v2.js"></script>


### PR DESCRIPTION
Unfortunately that's the only way to override the inlined CSS coming down from Hubspot.