### PR TITLE
Set Hubspot patch to min-height

### DIFF
--- a/partials/subscribe-form.hbs
+++ b/partials/subscribe-form.hbs
@@ -16,7 +16,7 @@
           <style>
           /* Correctly style subscription confirmation in Firefox */
           @-moz-document url-prefix() {
-            #site-main.site-main .hbspt-form iframe { height: auto !important; }
+            #site-main.site-main .hbspt-form iframe { min-height: 35px !important; }
           }
           </style>
           <script charset="utf-8" type="text/javascript" src="//js.hsforms.net/forms/v2.js"></script>


### PR DESCRIPTION
Setting `height` (predictably) clipped the non-scrollable hubspot form. This should enable the form to occupy its full height before being filled out, and yet prevent collapsing on the confirmation message.