### PR TITLE
Bump Ghost's deploy theme to v1.6.1 (latest)

### DIFF
--- a/.github/workflows/deploy-theme.yml
+++ b/.github/workflows/deploy-theme.yml
@@ -15,7 +15,7 @@ jobs:
       - run: yarn build
       - run: yarn test
       - name: Deploy Ghost Theme
-        uses: TryGhost/action-deploy-theme@v1.4.0
+        uses: TryGhost/action-deploy-theme@v1.6.1
         with:
           api-url: ${{ secrets.GHOST_ADMIN_API_URL }}
           api-key: ${{ secrets.GHOST_ADMIN_API_KEY }}

--- a/.github/workflows/stage-theme.yml
+++ b/.github/workflows/stage-theme.yml
@@ -15,7 +15,7 @@ jobs:
       - run: yarn build
       - run: yarn test
       - name: Stage Ghost Theme
-        uses: TryGhost/action-deploy-theme@v1.4.0
+        uses: TryGhost/action-deploy-theme@v1.6.1
         with:
           api-url: ${{ secrets.GHOST_ADMIN_STAGING_API_URL }}
           api-key: ${{ secrets.GHOST_ADMIN_STAGING_API_KEY }}


### PR DESCRIPTION
This should suppress a complaint from GitHub about an older version (12) of Node.js actions. (see for e.g.,
https://github.com/daily-co/casper-daily-theme/actions/runs/3251007622)

TryGhost/action-deploy-theme is currently at v1.6.1: https://github.com/TryGhost/action-deploy-theme/releases